### PR TITLE
Update documentation to use stayInaccuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Type: `function(msg)`, default `() => {}`
 
 Used to log debug messages in StayScrolled, usually `(msg) => { console.log(msg); }`
 
-### stayAccuracy
+### stayInaccuracy
 
 Type: `number`, default: `0`
 


### PR DESCRIPTION
## Overview

I noticed that the actual prop name is `stayInaccuracy` instead of `stayAccuracy` (see [here](https://github.com/perrin4869/react-stay-scrolled/blob/edcb8b7d574e59139a58aa4725ca49b3cf35e461/src/stay_scrolled.js#L15))